### PR TITLE
Use v2 endpoint for charts

### DIFF
--- a/src/__tests__/components/__snapshots__/ImportPage.test.js.snap
+++ b/src/__tests__/components/__snapshots__/ImportPage.test.js.snap
@@ -49,13 +49,13 @@ exports[`renders snapshots renders loader 1`] = `
     className="css-0"
   >
     <div
-      className="css-zdf5pk-style"
+      className="css-zk09k7"
     />
     <div
-      className="css-mym47v-style"
+      className="css-aisv07"
     />
     <div
-      className="css-1moxn8g-style"
+      className="css-bydlqq"
     />
   </div>
 </div>

--- a/src/__tests__/components/__snapshots__/ImportPage.test.js.snap
+++ b/src/__tests__/components/__snapshots__/ImportPage.test.js.snap
@@ -49,13 +49,13 @@ exports[`renders snapshots renders loader 1`] = `
     className="css-0"
   >
     <div
-      className="css-zk09k7"
+      className="css-zdf5pk-style"
     />
     <div
-      className="css-aisv07"
+      className="css-mym47v-style"
     />
     <div
-      className="css-bydlqq"
+      className="css-1moxn8g-style"
     />
   </div>
 </div>

--- a/src/__tests__/components/__snapshots__/chart.test.js.snap
+++ b/src/__tests__/components/__snapshots__/chart.test.js.snap
@@ -31,34 +31,41 @@ exports[`renders snapshots renders a <Chart/> snapshot 1`] = `
       id="chart"
     />
     <div>
-      <h2>
-        Stats
-      </h2>
-      <h3>
-        an_income
-        : 
-        $123.00
-      </h3>
-      <h3>
-        an_expense
-        : 
-        $123.00
-      </h3>
-      <h3>
-        Total Income
-        : 
-        $123.00
-      </h3>
-      <h3>
-        Total Expense
-        : 
-        $123.00
-      </h3>
-      <h3>
-        Profit/Loss
-        : 
-        $0.00
-      </h3>
+      <div>
+        <h2>
+          Stats
+        </h2>
+        <h3>
+          Profit/Loss
+          : 
+          $0.00
+        </h3>
+        <h3>
+          Total Expense
+          : 
+          $123.00
+        </h3>
+        <h3>
+          Total Income
+          : 
+          $123.00
+        </h3>
+      </div>
+      <div>
+        <h2>
+          Totals
+        </h2>
+        <h3>
+          an_expense
+          : 
+          $123.00
+        </h3>
+        <h3>
+          an_income
+          : 
+          $123.00
+        </h3>
+      </div>
     </div>
   </div>
 </div>
@@ -82,13 +89,13 @@ exports[`renders snapshots renders loader 1`] = `
     className="css-0"
   >
     <div
-      className="css-zk09k7"
+      className="css-zdf5pk-style"
     />
     <div
-      className="css-aisv07"
+      className="css-mym47v-style"
     />
     <div
-      className="css-bydlqq"
+      className="css-1moxn8g-style"
     />
   </div>
 </div>

--- a/src/__tests__/components/__snapshots__/chart.test.js.snap
+++ b/src/__tests__/components/__snapshots__/chart.test.js.snap
@@ -89,13 +89,13 @@ exports[`renders snapshots renders loader 1`] = `
     className="css-0"
   >
     <div
-      className="css-zdf5pk-style"
+      className="css-zk09k7"
     />
     <div
-      className="css-mym47v-style"
+      className="css-aisv07"
     />
     <div
-      className="css-1moxn8g-style"
+      className="css-bydlqq"
     />
   </div>
 </div>

--- a/src/__tests__/components/chart.test.js
+++ b/src/__tests__/components/chart.test.js
@@ -41,21 +41,27 @@ const newState = {
     load: true,
     stats: {
         "2019": {
-            "Annual Profit/Loss": "0.0",
-            "Average Expense per Month": "not enough data",
-            "Average Income per Month": "not enough data",
-            "Estimated Annual Expense": "not enough data",
-            "Estimated Annual Income": "not enough data",
-            "Total Expenses": "123.0",
-            "Total Income": "123.0",
-            "avg_cat_month": {"an_expense": "not enough data"}
+            "Stats": {
+                "Annual Profit/Loss": "0.0",
+                "Average Expense per Month": "not enough data",
+                "Average Income per Month": "not enough data",
+                "Estimated Annual Expense": "not enough data",
+                "Estimated Annual Income": "not enough data",
+                "Total Expenses": "123.0",
+                "Total Income": "123.0"   
+            },
+            "Monthly Averages": {"an_expense": "not enough data"}
         },
         "December": {
-            "an_income": "123.0",
-            "an_expense": "123.0",
-            "Total Income": "123.0",
-            "Total Expense": "123.0",
-            "Profit/Loss": "0.0"
+            "Stats": {
+                "Total Income": "123.0",
+                "Total Expense": "123.0",
+                "Profit/Loss": "0.0"
+            },
+            "Totals": {
+                "an_income": "123.0",
+                "an_expense": "123.0"
+            }
         }
     }
 }

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -25,13 +25,13 @@ export class Chart extends React.Component {
       }
     }
 
-    fetch(`${process.env.REACT_APP_API}/api/v1/charts/${id}`, options)
+    fetch(`${process.env.REACT_APP_API}/api/v2/charts/${id}`, options)
       .then(resp => resp.json())
       .then(resp => {if (resp.error) {
         this.setState({error: resp.error})
       } else {
         const titles = Object.keys(resp.charts)
-        const lastMonth = titles[titles.length - 1]
+        const lastMonth = titles[titles.length - 1]        
         this.setState({
           charts: resp.charts,
           stats: resp.stats,
@@ -118,13 +118,8 @@ export class Chart extends React.Component {
               </select>
               <div id="chart" />
               <div>
-                <h2>Stats</h2>
-                {Object.keys(stats[this.state.currentTitle]).map( title => {
-                  if (title === "avg_cat_month") {
-                    return <div key={title}><h2>Monthly Averages</h2>{Object.keys(stats[this.state.currentTitle][title]).map( title => <h3 key={title}>{title}: {formatMoney(stats[this.state.currentTitle]["avg_cat_month"][title])}</h3>)}</div>
-                  } else {
-                    return ( <h3 key={title}>{title}: {formatMoney(stats[this.state.currentTitle][title])}</h3> )
-                  }
+                {Object.keys(stats[this.state.currentTitle]).sort().map( title => {
+                  return <div key={title}><h2>{title}</h2>{Object.keys(stats[this.state.currentTitle][title]).sort().map( subtitle => <h3 key={subtitle}>{subtitle}: {formatMoney(stats[this.state.currentTitle][title][subtitle])}</h3>)}</div>
                 })
                 }
               </div>


### PR DESCRIPTION
This changes the charts page to use a v2 endpoint which separates stats and totals.
This sorts categories on charts page before displaying stats and totals.